### PR TITLE
Adding new FileReference/BuildFile API

### DIFF
--- a/Package.pins
+++ b/Package.pins
@@ -8,16 +8,100 @@
       "version": "0.2.1-rc1"
     },
     {
+      "package": "Clang_C",
+      "reason": null,
+      "repositoryURL": "https://github.com/norio-nomura/Clang_C.git",
+      "version": "1.0.2"
+    },
+    {
+      "package": "Commandant",
+      "reason": null,
+      "repositoryURL": "https://github.com/Carthage/Commandant.git",
+      "version": "0.12.0"
+    },
+    {
+      "package": "Commander",
+      "reason": null,
+      "repositoryURL": "https://github.com/kylef/Commander.git",
+      "version": "0.6.1"
+    },
+    {
+      "package": "CommonCrypto",
+      "reason": null,
+      "repositoryURL": "https://github.com/IBM-Swift/CommonCrypto.git",
+      "version": "0.1.4"
+    },
+    {
       "package": "PathKit",
       "reason": null,
       "repositoryURL": "https://github.com/kylef/PathKit.git",
       "version": "0.8.0"
     },
     {
+      "package": "Result",
+      "reason": null,
+      "repositoryURL": "https://github.com/antitypical/Result.git",
+      "version": "3.2.2"
+    },
+    {
+      "package": "SWXMLHash",
+      "reason": null,
+      "repositoryURL": "https://github.com/drmohundro/SWXMLHash.git",
+      "version": "3.0.5"
+    },
+    {
+      "package": "SourceKit",
+      "reason": null,
+      "repositoryURL": "https://github.com/norio-nomura/SourceKit.git",
+      "version": "1.0.1"
+    },
+    {
+      "package": "SourceKitten",
+      "reason": null,
+      "repositoryURL": "https://github.com/jpsim/SourceKitten.git",
+      "version": "0.17.3"
+    },
+    {
+      "package": "Sourcery",
+      "reason": null,
+      "repositoryURL": "https://github.com/krzysztofzablocki/Sourcery.git",
+      "version": "0.6.0"
+    },
+    {
       "package": "Spectre",
       "reason": null,
       "repositoryURL": "https://github.com/kylef/Spectre.git",
       "version": "0.7.2"
+    },
+    {
+      "package": "Stencil",
+      "reason": null,
+      "repositoryURL": "https://github.com/kylef/Stencil.git",
+      "version": "0.8.0"
+    },
+    {
+      "package": "StencilSwiftKit",
+      "reason": null,
+      "repositoryURL": "https://github.com/SwiftGen/StencilSwiftKit.git",
+      "version": "1.0.1"
+    },
+    {
+      "package": "SwiftTryCatch",
+      "reason": null,
+      "repositoryURL": "https://github.com/vknabel/SwiftTryCatch.git",
+      "version": "1.1.0"
+    },
+    {
+      "package": "XcodeEdit",
+      "reason": null,
+      "repositoryURL": "https://github.com/tomlokhorst/XcodeEdit.git",
+      "version": "1.1.0"
+    },
+    {
+      "package": "Yams",
+      "reason": null,
+      "repositoryURL": "https://github.com/jpsim/Yams.git",
+      "version": "0.3.2"
     }
   ],
   "version": 1

--- a/Package.pins
+++ b/Package.pins
@@ -5,7 +5,7 @@
       "package": "AsciiPlistParser",
       "reason": null,
       "repositoryURL": "https://github.com/toshi0383/AsciiPlistParser.git",
-      "version": "0.2.1-rc1"
+      "version": "0.2.1"
     },
     {
       "package": "Clang_C",

--- a/Package.pins
+++ b/Package.pins
@@ -8,100 +8,16 @@
       "version": "0.1.2-rc7"
     },
     {
-      "package": "Clang_C",
-      "reason": null,
-      "repositoryURL": "https://github.com/norio-nomura/Clang_C.git",
-      "version": "1.0.2"
-    },
-    {
-      "package": "Commandant",
-      "reason": null,
-      "repositoryURL": "https://github.com/Carthage/Commandant.git",
-      "version": "0.12.0"
-    },
-    {
-      "package": "Commander",
-      "reason": null,
-      "repositoryURL": "https://github.com/kylef/Commander.git",
-      "version": "0.6.1"
-    },
-    {
-      "package": "CommonCrypto",
-      "reason": null,
-      "repositoryURL": "https://github.com/IBM-Swift/CommonCrypto.git",
-      "version": "0.1.4"
-    },
-    {
       "package": "PathKit",
       "reason": null,
       "repositoryURL": "https://github.com/kylef/PathKit.git",
       "version": "0.8.0"
     },
     {
-      "package": "Result",
-      "reason": null,
-      "repositoryURL": "https://github.com/antitypical/Result.git",
-      "version": "3.2.1"
-    },
-    {
-      "package": "SWXMLHash",
-      "reason": null,
-      "repositoryURL": "https://github.com/drmohundro/SWXMLHash.git",
-      "version": "3.0.5"
-    },
-    {
-      "package": "SourceKit",
-      "reason": null,
-      "repositoryURL": "https://github.com/norio-nomura/SourceKit.git",
-      "version": "1.0.1"
-    },
-    {
-      "package": "SourceKitten",
-      "reason": null,
-      "repositoryURL": "https://github.com/jpsim/SourceKitten.git",
-      "version": "0.17.3"
-    },
-    {
-      "package": "Sourcery",
-      "reason": null,
-      "repositoryURL": "https://github.com/krzysztofzablocki/Sourcery.git",
-      "version": "0.6.0"
-    },
-    {
       "package": "Spectre",
       "reason": null,
       "repositoryURL": "https://github.com/kylef/Spectre.git",
       "version": "0.7.2"
-    },
-    {
-      "package": "Stencil",
-      "reason": null,
-      "repositoryURL": "https://github.com/kylef/Stencil.git",
-      "version": "0.8.0"
-    },
-    {
-      "package": "StencilSwiftKit",
-      "reason": null,
-      "repositoryURL": "https://github.com/SwiftGen/StencilSwiftKit.git",
-      "version": "1.0.1"
-    },
-    {
-      "package": "SwiftTryCatch",
-      "reason": null,
-      "repositoryURL": "https://github.com/vknabel/SwiftTryCatch.git",
-      "version": "1.1.0"
-    },
-    {
-      "package": "XcodeEdit",
-      "reason": null,
-      "repositoryURL": "https://github.com/tomlokhorst/XcodeEdit.git",
-      "version": "1.1.0"
-    },
-    {
-      "package": "Yams",
-      "reason": null,
-      "repositoryURL": "https://github.com/jpsim/Yams.git",
-      "version": "0.3.2"
     }
   ],
   "version": 1

--- a/Package.pins
+++ b/Package.pins
@@ -5,7 +5,7 @@
       "package": "AsciiPlistParser",
       "reason": null,
       "repositoryURL": "https://github.com/toshi0383/AsciiPlistParser.git",
-      "version": "0.1.2-rc7"
+      "version": "0.2.1-rc1"
     },
     {
       "package": "PathKit",

--- a/Resources/SourceryTemplates/AutoPbxSubscript.stencil
+++ b/Resources/SourceryTemplates/AutoPbxSubscript.stencil
@@ -14,7 +14,8 @@ extension {{ type.name }} {
                 object[keyref] = existing
             } else {
                 let keyref = KeyRef(value: field.rawValue, annotation: nil)
-                object[keyref] = newValue
+                let stringValue = StringValue(value: newValue, annotation: nil)
+                object[keyref] = stringValue
             }
         }
         get {
@@ -31,7 +32,7 @@ extension {{ type.name }} {
                 object[keyref] = existing
             } else {
                 let keyref = KeyRef(value: field.rawValue, annotation: nil)
-                object[keyref] = newValue
+                object[keyref] = ArrayValue(value: newValue)
             }
         }
         get {
@@ -63,7 +64,11 @@ extension {{ type.name }} {
                 }
             } else {
                 let keyref = KeyRef(value: field.rawValue, annotation: nil)
-                object[keyref] = newValue
+                if let newValue = newValue {
+                    object[keyref] = StringValue(value: newValue, annotation: nil)
+                } else {
+                    object[keyref] = nil
+                }
             }
         }
         get {
@@ -84,7 +89,11 @@ extension {{ type.name }} {
                 }
             } else {
                 let keyref = KeyRef(value: field.rawValue, annotation: nil)
-                object[keyref] = newValue
+                if let newValue = newValue {
+                    object[keyref] = ArrayValue(value: newValue)
+                } else {
+                    object[keyref] = nil
+                }
             }
         }
         get {

--- a/Resources/SourceryTemplates/AutoPbxSubscript.stencil
+++ b/Resources/SourceryTemplates/AutoPbxSubscript.stencil
@@ -136,6 +136,24 @@ extension {{ type.name }} {
     }
     {% endif %}
     {% endif %}
+    {% if t.name|hasSuffix:".GroupReferencingField" %}
+    {% if type.implements.ObjectsReferencing %}
+    public var {{ c.name }}: Group {
+        let id = object.string(for: "{{ c.name }}")!
+        return Group(object: objects.object(for: id)!, objects: objects)
+    }
+    {% endif %}
+    {% endif %}
+    {% if t.name|hasSuffix:".OptionalGroupReferencingField" %}
+    {% if type.implements.ObjectsReferencing %}
+    public var {{ c.name }}: Group? {
+        guard let id = object.string(for: "{{ c.name }}") else {
+            return nil
+        }
+        return Group(object: objects.object(for: id)!, objects: objects)
+    }
+    {% endif %}
+    {% endif %}
     {% if t.name|hasSuffix:".FileReferencingField" %}
     {% if type.implements.ObjectsReferencing %}
     public var {{ c.name }}: FileReference {

--- a/Resources/SourceryTemplates/AutoPbxSubscript.swifttemplate
+++ b/Resources/SourceryTemplates/AutoPbxSubscript.swifttemplate
@@ -6,12 +6,20 @@ extension <%= type.name %> {
 <% for t in type.containedTypes { %>
 <% guard let e = t as? Enum else { return } %>
 <% for c in e.cases { %>
-    <%_ %><% if t.name.hasSuffix(".ObjectsReferencingArrayField") { %>
+    <%_ %><% if t.name.hasSuffix(".ObjectReferencingArrayField") { %>
     <%_ %><% if type.implements["ObjectsReferencing"] != nil { %>
     <%_ %><% let typename = c.name.characters.map{String($0)}.reduce([]){ $0.isEmpty ? [$1.uppercased()] : $0 + [$1]}.dropLast().joined() %>
     public var <%= c.name %>: [<%= typename %>] {
         let ids = object.stringArray(for: "<%= c.name %>")!
         return ids.map(objectTuple).map(<%= typename %>.init)
+    }
+    <%_ %><% } %>
+    <%_ %><% } %>
+    <%_ %><% if t.name.hasSuffix(".AnyIsaObjectReferencingArrayField") { %>
+    <%_ %><% if type.implements["ObjectsReferencing"] != nil { %>
+    public var <%= c.name %>: [AnyIsaObject] {
+        let ids = object.stringArray(for: "<%= c.name %>")!
+        return ids.map(objectTuple).map(AnyIsaObject.init)
     }
     <%_ %><% } %>
     <%_ %><% } %>

--- a/Sources/PBXProj/AutoEquatables.out.swift
+++ b/Sources/PBXProj/AutoEquatables.out.swift
@@ -24,6 +24,13 @@ fileprivate func compareArrays<T>(lhs: [T], rhs: [T], compare: (_ lhs: T, _ rhs:
 }
 
 // MARK: - AutoEquatable for classes, protocols, structs
+// MARK: - FileReference AutoEquatable
+extension FileReference: Equatable {} 
+public func == (lhs: FileReference, rhs: FileReference) -> Bool {
+    guard lhs.object == rhs.object else { return false }
+    guard lhs.objects == rhs.objects else { return false }
+    return true
+}
 
 // MARK: - AutoEquatable for Enums
 

--- a/Sources/PBXProj/AutoEquatables.swift
+++ b/Sources/PBXProj/AutoEquatables.swift
@@ -1,0 +1,13 @@
+//
+//  AutoEquatables.swift
+//  Pbxproj
+//
+//  Created by Toshihiro suzuki on 2017/05/18.
+//
+//
+
+import Foundation
+
+protocol AutoEquatable { }
+
+extension FileReference: AutoEquatable { }

--- a/Sources/PBXProj/AutoPbxSubscript.out.swift
+++ b/Sources/PBXProj/AutoPbxSubscript.out.swift
@@ -164,6 +164,10 @@ extension FileReference {
         get { return self[.name] }
         set(newValue) { self[.name] = newValue }
     }
+    public var fileEncoding: String? {
+        get { return self[.fileEncoding] }
+        set(newValue) { self[.fileEncoding] = newValue }
+    }
 
 }
 // MARK: Group

--- a/Sources/PBXProj/AutoPbxSubscript.out.swift
+++ b/Sources/PBXProj/AutoPbxSubscript.out.swift
@@ -14,7 +14,8 @@ extension BuildConfiguration {
                 object[keyref] = existing
             } else {
                 let keyref = KeyRef(value: field.rawValue, annotation: nil)
-                object[keyref] = newValue
+                let stringValue = StringValue(value: newValue, annotation: nil)
+                object[keyref] = stringValue
             }
         }
         get {
@@ -67,7 +68,11 @@ extension BuildConfigurationList {
                 }
             } else {
                 let keyref = KeyRef(value: field.rawValue, annotation: nil)
-                object[keyref] = newValue
+                if let newValue = newValue {
+                    object[keyref] = StringValue(value: newValue, annotation: nil)
+                } else {
+                    object[keyref] = nil
+                }
             }
         }
         get {
@@ -88,7 +93,8 @@ extension BuildConfigurationList {
                 object[keyref] = existing
             } else {
                 let keyref = KeyRef(value: field.rawValue, annotation: nil)
-                object[keyref] = newValue
+                let stringValue = StringValue(value: newValue, annotation: nil)
+                object[keyref] = stringValue
             }
         }
         get {
@@ -106,6 +112,8 @@ extension BuildConfigurationList {
 extension FileReference {
 
 
+
+
     subscript(field: StringField) -> String {
         set(newValue) {
             if let keyref = object.keyRef(for: field.rawValue) {
@@ -114,7 +122,8 @@ extension FileReference {
                 object[keyref] = existing
             } else {
                 let keyref = KeyRef(value: field.rawValue, annotation: nil)
-                object[keyref] = newValue
+                let stringValue = StringValue(value: newValue, annotation: nil)
+                object[keyref] = stringValue
             }
         }
         get {
@@ -125,10 +134,6 @@ extension FileReference {
     public var path: String {
         get { return self[.path] }
         set(newValue) { self[.path] = newValue }
-    }
-    public var sourceTree: String {
-        get { return self[.sourceTree] }
-        set(newValue) { self[.sourceTree] = newValue }
     }
 
     subscript(field: OptionalStringField) -> String? {
@@ -143,7 +148,11 @@ extension FileReference {
                 }
             } else {
                 let keyref = KeyRef(value: field.rawValue, annotation: nil)
-                object[keyref] = newValue
+                if let newValue = newValue {
+                    object[keyref] = StringValue(value: newValue, annotation: nil)
+                } else {
+                    object[keyref] = nil
+                }
             }
         }
         get {
@@ -167,7 +176,7 @@ extension Group {
                 object[keyref] = existing
             } else {
                 let keyref = KeyRef(value: field.rawValue, annotation: nil)
-                object[keyref] = newValue
+                object[keyref] = ArrayValue(value: newValue)
             }
         }
         get {
@@ -188,7 +197,8 @@ extension Group {
                 object[keyref] = existing
             } else {
                 let keyref = KeyRef(value: field.rawValue, annotation: nil)
-                object[keyref] = newValue
+                let stringValue = StringValue(value: newValue, annotation: nil)
+                object[keyref] = stringValue
             }
         }
         get {
@@ -213,7 +223,11 @@ extension Group {
                 }
             } else {
                 let keyref = KeyRef(value: field.rawValue, annotation: nil)
-                object[keyref] = newValue
+                if let newValue = newValue {
+                    object[keyref] = StringValue(value: newValue, annotation: nil)
+                } else {
+                    object[keyref] = nil
+                }
             }
         }
         get {
@@ -247,7 +261,8 @@ extension Pbxproj {
                 object[keyref] = existing
             } else {
                 let keyref = KeyRef(value: field.rawValue, annotation: nil)
-                object[keyref] = newValue
+                let stringValue = StringValue(value: newValue, annotation: nil)
+                object[keyref] = stringValue
             }
         }
         get {
@@ -272,7 +287,7 @@ extension Pbxproj {
                 object[keyref] = existing
             } else {
                 let keyref = KeyRef(value: field.rawValue, annotation: nil)
-                object[keyref] = newValue
+                object[keyref] = ArrayValue(value: newValue)
             }
         }
         get {
@@ -308,7 +323,11 @@ extension Pbxproj {
                 }
             } else {
                 let keyref = KeyRef(value: field.rawValue, annotation: nil)
-                object[keyref] = newValue
+                if let newValue = newValue {
+                    object[keyref] = StringValue(value: newValue, annotation: nil)
+                } else {
+                    object[keyref] = nil
+                }
             }
         }
         get {
@@ -329,7 +348,11 @@ extension Pbxproj {
                 }
             } else {
                 let keyref = KeyRef(value: field.rawValue, annotation: nil)
-                object[keyref] = newValue
+                if let newValue = newValue {
+                    object[keyref] = ArrayValue(value: newValue)
+                } else {
+                    object[keyref] = nil
+                }
             }
         }
         get {
@@ -374,7 +397,8 @@ extension RootObject {
                 object[keyref] = existing
             } else {
                 let keyref = KeyRef(value: field.rawValue, annotation: nil)
-                object[keyref] = newValue
+                let stringValue = StringValue(value: newValue, annotation: nil)
+                object[keyref] = stringValue
             }
         }
         get {
@@ -411,7 +435,7 @@ extension RootObject {
                 object[keyref] = existing
             } else {
                 let keyref = KeyRef(value: field.rawValue, annotation: nil)
-                object[keyref] = newValue
+                object[keyref] = ArrayValue(value: newValue)
             }
         }
         get {
@@ -455,7 +479,11 @@ extension RootObject {
                 }
             } else {
                 let keyref = KeyRef(value: field.rawValue, annotation: nil)
-                object[keyref] = newValue
+                if let newValue = newValue {
+                    object[keyref] = StringValue(value: newValue, annotation: nil)
+                } else {
+                    object[keyref] = nil
+                }
             }
         }
         get {
@@ -487,7 +515,8 @@ extension Target {
                 object[keyref] = existing
             } else {
                 let keyref = KeyRef(value: field.rawValue, annotation: nil)
-                object[keyref] = newValue
+                let stringValue = StringValue(value: newValue, annotation: nil)
+                object[keyref] = stringValue
             }
         }
         get {
@@ -522,7 +551,11 @@ extension Target {
                 }
             } else {
                 let keyref = KeyRef(value: field.rawValue, annotation: nil)
-                object[keyref] = newValue
+                if let newValue = newValue {
+                    object[keyref] = ArrayValue(value: newValue)
+                } else {
+                    object[keyref] = nil
+                }
             }
         }
         get {
@@ -543,7 +576,7 @@ extension Target {
                 object[keyref] = existing
             } else {
                 let keyref = KeyRef(value: field.rawValue, annotation: nil)
-                object[keyref] = newValue
+                object[keyref] = ArrayValue(value: newValue)
             }
         }
         get {

--- a/Sources/PBXProj/AutoPbxSubscript.out.swift
+++ b/Sources/PBXProj/AutoPbxSubscript.out.swift
@@ -131,6 +131,31 @@ extension FileReference {
         set(newValue) { self[.sourceTree] = newValue }
     }
 
+    subscript(field: OptionalStringField) -> String? {
+        set(newValue) {
+            if let keyref = object.keyRef(for: field.rawValue) {
+                if let newValue = newValue {
+                    let existing = object[keyref] as! StringValue
+                    existing.value = newValue
+                    object[keyref] = existing
+                } else {
+                    object[keyref] = nil
+                }
+            } else {
+                let keyref = KeyRef(value: field.rawValue, annotation: nil)
+                object[keyref] = newValue
+            }
+        }
+        get {
+            return object.string(for: field.rawValue)
+        }
+    }
+
+    public var name: String? {
+        get { return self[.name] }
+        set(newValue) { self[.name] = newValue }
+    }
+
 }
 // MARK: Group
 extension Group {
@@ -369,10 +394,6 @@ extension RootObject {
         get { return self[.hasScannedForEncodings] }
         set(newValue) { self[.hasScannedForEncodings] = newValue }
     }
-    public var mainGroup: String {
-        get { return self[.mainGroup] }
-        set(newValue) { self[.mainGroup] = newValue }
-    }
     public var productRefGroup: String {
         get { return self[.productRefGroup] }
         set(newValue) { self[.productRefGroup] = newValue }
@@ -448,6 +469,12 @@ extension RootObject {
     }
 
 
+
+
+    public var mainGroup: Group {
+        let id = object.string(for: "mainGroup")!
+        return Group(object: objects.object(for: id)!, objects: objects)
+    }
 
 }
 // MARK: Target

--- a/Sources/PBXProj/AutoPbxSubscript.out.swift
+++ b/Sources/PBXProj/AutoPbxSubscript.out.swift
@@ -4,6 +4,9 @@
 
 import AsciiPlistParser
 
+// MARK: AnyIsaObject
+extension AnyIsaObject {
+}
 // MARK: BuildConfiguration
 extension BuildConfiguration {
     subscript(field: StringField) -> String {
@@ -105,6 +108,81 @@ extension BuildConfigurationList {
     public var defaultConfigurationIsVisible: String {
         get { return self[.defaultConfigurationIsVisible] }
         set(newValue) { self[.defaultConfigurationIsVisible] = newValue }
+    }
+
+}
+// MARK: BuildFile
+extension BuildFile {
+    subscript(field: StringField) -> String {
+        set(newValue) {
+            if let keyref = object.keyRef(for: field.rawValue) {
+                let existing = object[keyref] as! StringValue
+                existing.value = newValue
+                object[keyref] = existing
+            } else {
+                let keyref = KeyRef(value: field.rawValue, annotation: nil)
+                let stringValue = StringValue(value: newValue, annotation: nil)
+                object[keyref] = stringValue
+            }
+        }
+        get {
+            return object.string(for: field.rawValue)!
+        }
+    }
+
+    public var fileRef: String {
+        get { return self[.fileRef] }
+        set(newValue) { self[.fileRef] = newValue }
+    }
+
+}
+// MARK: BuildPhase
+extension BuildPhase {
+    subscript(field: StringField) -> String {
+        set(newValue) {
+            if let keyref = object.keyRef(for: field.rawValue) {
+                let existing = object[keyref] as! StringValue
+                existing.value = newValue
+                object[keyref] = existing
+            } else {
+                let keyref = KeyRef(value: field.rawValue, annotation: nil)
+                let stringValue = StringValue(value: newValue, annotation: nil)
+                object[keyref] = stringValue
+            }
+        }
+        get {
+            return object.string(for: field.rawValue)!
+        }
+    }
+
+    public var buildActionMask: String {
+        get { return self[.buildActionMask] }
+        set(newValue) { self[.buildActionMask] = newValue }
+    }
+    public var runOnlyForDeploymentPostprocessing: String {
+        get { return self[.runOnlyForDeploymentPostprocessing] }
+        set(newValue) { self[.runOnlyForDeploymentPostprocessing] = newValue }
+    }
+
+    subscript(field: ArrayField) -> [StringValue] {
+        set(newValue) {
+            if let keyref = object.keyRef(for: field.rawValue) {
+                let existing = object[keyref] as! ArrayValue
+                existing.value = newValue
+                object[keyref] = existing
+            } else {
+                let keyref = KeyRef(value: field.rawValue, annotation: nil)
+                object[keyref] = ArrayValue(value: newValue)
+            }
+        }
+        get {
+            return object.arrayValue(for: field.rawValue)!.value
+        }
+    }
+
+    public var files: [StringValue] {
+        get { return self[.files] }
+        set(newValue) { self[.files] = newValue }
     }
 
 }
@@ -598,5 +676,7 @@ extension Target {
         let id = object.string(for: "buildConfigurationList")!
         return BuildConfigurationList(object: objects.object(for: id)!, objects: objects)
     }
+
+
 
 }

--- a/Sources/PBXProj/AutoPbxSubscript2.out.swift
+++ b/Sources/PBXProj/AutoPbxSubscript2.out.swift
@@ -70,6 +70,11 @@ extension FileReference {
 
 
 
+
+
+
+
+
 }
 
 // MARK: Group
@@ -184,12 +189,15 @@ extension RootObject {
 
 
 
-
-
     public var targets: [Target] {
         let ids = object.stringArray(for: "targets")!
         return ids.map(objectTuple).map(Target.init)
     }
+
+
+
+
+
 
 
 

--- a/Sources/PBXProj/AutoPbxSubscript2.out.swift
+++ b/Sources/PBXProj/AutoPbxSubscript2.out.swift
@@ -5,8 +5,16 @@
 import AsciiPlistParser
 
 
+// MARK: AnyIsaObject
+extension AnyIsaObject {
+
+}
+
 // MARK: BuildConfiguration
 extension BuildConfiguration {
+
+
+
 
 
 
@@ -51,10 +59,52 @@ extension BuildConfigurationList {
 
 
 
+
+
+
+}
+
+// MARK: BuildFile
+extension BuildFile {
+
+
+
+
+
+
+
+}
+
+// MARK: BuildPhase
+extension BuildPhase {
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 }
 
 // MARK: FileReference
 extension FileReference {
+
+
+
+
+
+
+
+
 
 
 
@@ -100,6 +150,10 @@ extension Group {
 
 
 
+
+
+
+
 }
 
 // MARK: IsaObject
@@ -114,6 +168,14 @@ extension ObjectsReferencing {
 
 // MARK: Pbxproj
 extension Pbxproj {
+
+
+
+
+
+
+
+
 
 
 
@@ -192,10 +254,21 @@ extension RootObject {
 
 
 
+
+
+
+
+
+
+
+
+
     public var targets: [Target] {
         let ids = object.stringArray(for: "targets")!
         return ids.map(objectTuple).map(Target.init)
     }
+
+
 
 
 
@@ -234,6 +307,27 @@ extension Target {
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    public var buildPhases: [BuildPhase] {
+        let ids = object.stringArray(for: "buildPhases")!
+        return ids.map(objectTuple).map(BuildPhase.init)
+    }
 
 
 

--- a/Sources/PBXProj/AutoPbxSubscript2.out.swift
+++ b/Sources/PBXProj/AutoPbxSubscript2.out.swift
@@ -75,6 +75,9 @@ extension FileReference {
 
 
 
+
+
+
 }
 
 // MARK: Group

--- a/Sources/PBXProj/BuildConfigurationList.swift
+++ b/Sources/PBXProj/BuildConfigurationList.swift
@@ -10,7 +10,7 @@ import Foundation
 import AsciiPlistParser
 
 public class BuildConfigurationList: IsaObject, ObjectsReferencing {
-    enum ObjectsReferencingArrayField {
+    enum ObjectReferencingArrayField {
         case buildConfigurations
     }
     enum OptionalStringField: String {

--- a/Sources/PBXProj/BuildFile.swift
+++ b/Sources/PBXProj/BuildFile.swift
@@ -1,0 +1,33 @@
+//
+//  BuildFile.swift
+//  Pbxproj
+//
+//  Created by Toshihiro suzuki on 2017/05/18.
+//
+//
+
+import Foundation
+import AsciiPlistParser
+import PathKit
+
+final public class BuildFile: IsaObject, ObjectsReferencing {
+    enum StringField: String {
+        case fileRef
+    }
+    public let object: Object
+    public let objects: Object
+    public init(object: Object, objects: Object) {
+        self.object = object
+        self.objects = objects
+    }
+}
+
+extension BuildFile {
+    static func create(fileRef: String) -> BuildFile {
+        let buildfile = BuildFile(object: [:], objects: [:])
+        buildfile[.fileRef] = fileRef
+        buildfile.object["isa"] = StringValue(value: IsaType.PBXBuildFile.rawValue, annotation: nil)
+        assert(buildfile.isa == .PBXBuildFile)
+        return buildfile
+    }
+}

--- a/Sources/PBXProj/BuildPhase.swift
+++ b/Sources/PBXProj/BuildPhase.swift
@@ -12,9 +12,6 @@ final public class BuildPhase: IsaObject, ObjectsReferencing {
     enum ArrayField: String {
         case files
     }
-//    enum AnyIsaObjectReferencingArrayField: String {
-//        case files
-//    }
     public let object: Object
     public let objects: Object
     public init(object: Object, objects: Object) {
@@ -22,42 +19,3 @@ final public class BuildPhase: IsaObject, ObjectsReferencing {
         self.objects = objects
     }
 }
-
-public class AnyIsaObject: IsaObject, ObjectsReferencing {
-    public let object: Object
-    public let objects: Object
-    public init(object: Object, objects: Object) {
-        self.object = object
-        self.objects = objects
-    }
-}
-
-//extension BuildPhase {
-//    subscript(field: AnyIsaObjectReferencingArrayField) -> [AnyIsaObject] {
-//        set(newValue) {
-//            let ids = newValue.map { objects }
-//            if let keyref = object.keyRef(for: field.rawValue) {
-//                let existing = object[keyref] as! ArrayValue
-//                existing.value = ids
-//                object[keyref] = existing
-//            } else {
-//                let keyref = KeyRef(value: field.rawValue, annotation: nil)
-//                let arrayValue = ArrayValue(value: ids, annotation: nil)
-//                object[keyref] = arrayValue
-//            }
-//        }
-//        get {
-//            return object.stringArray(for: field.rawValue)!.flatMap { id in
-//                guard let o = objects.object(for: id) else {
-//                    return nil
-//                }
-//                return AnyIsaObject(object: o, objects: objects)
-//            }
-//        }
-//    }
-//
-//    public var files: String {
-//        get { return self[.files] }
-//        set(newValue) { self[.files] = newValue }
-//    }
-//}

--- a/Sources/PBXProj/BuildPhase.swift
+++ b/Sources/PBXProj/BuildPhase.swift
@@ -1,0 +1,63 @@
+import Foundation
+import AsciiPlistParser
+import PathKit
+
+public typealias File = Object
+
+final public class BuildPhase: IsaObject, ObjectsReferencing {
+    enum StringField: String {
+        case buildActionMask
+        case runOnlyForDeploymentPostprocessing
+    }
+    enum ArrayField: String {
+        case files
+    }
+//    enum AnyIsaObjectReferencingArrayField: String {
+//        case files
+//    }
+    public let object: Object
+    public let objects: Object
+    public init(object: Object, objects: Object) {
+        self.object = object
+        self.objects = objects
+    }
+}
+
+public class AnyIsaObject: IsaObject, ObjectsReferencing {
+    public let object: Object
+    public let objects: Object
+    public init(object: Object, objects: Object) {
+        self.object = object
+        self.objects = objects
+    }
+}
+
+//extension BuildPhase {
+//    subscript(field: AnyIsaObjectReferencingArrayField) -> [AnyIsaObject] {
+//        set(newValue) {
+//            let ids = newValue.map { objects }
+//            if let keyref = object.keyRef(for: field.rawValue) {
+//                let existing = object[keyref] as! ArrayValue
+//                existing.value = ids
+//                object[keyref] = existing
+//            } else {
+//                let keyref = KeyRef(value: field.rawValue, annotation: nil)
+//                let arrayValue = ArrayValue(value: ids, annotation: nil)
+//                object[keyref] = arrayValue
+//            }
+//        }
+//        get {
+//            return object.stringArray(for: field.rawValue)!.flatMap { id in
+//                guard let o = objects.object(for: id) else {
+//                    return nil
+//                }
+//                return AnyIsaObject(object: o, objects: objects)
+//            }
+//        }
+//    }
+//
+//    public var files: String {
+//        get { return self[.files] }
+//        set(newValue) { self[.files] = newValue }
+//    }
+//}

--- a/Sources/PBXProj/Errors.swift
+++ b/Sources/PBXProj/Errors.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+enum AddFilesError: Error {
+    case filesNotFound
+}

--- a/Sources/PBXProj/FileReference.swift
+++ b/Sources/PBXProj/FileReference.swift
@@ -39,6 +39,7 @@ final public class FileReference: IsaObject, ObjectsReferencing {
     }
     enum OptionalStringField: String {
         case name
+        case fileEncoding
     }
     public let object: Object
     public let objects: Object
@@ -116,6 +117,9 @@ extension FileReference {
         let fileref = FileReference(object: [:], objects: [:])
         fileref[.lastKnownFileType] = .sourcecodeswift
         fileref[.sourceTree] = .group
+        fileref[.fileEncoding] = "4"
+        let filename = path.components.last!
+        fileref[.name] = filename
         fileref[.path] = path.normalize().string
         fileref.object["isa"] = StringValue(value: IsaType.PBXFileReference.rawValue, annotation: nil)
         assert(fileref.isa == .PBXFileReference)

--- a/Sources/PBXProj/FileReference.swift
+++ b/Sources/PBXProj/FileReference.swift
@@ -116,15 +116,10 @@ extension FileReference {
         let fileref = FileReference(object: [:], objects: [:])
         fileref[.lastKnownFileType] = .sourcecodeswift
         fileref[.sourceTree] = .group
-        fileref[.path] = path.string
+        fileref[.path] = path.normalize().string
         fileref.object["isa"] = StringValue(value: IsaType.PBXFileReference.rawValue, annotation: nil)
         assert(fileref.isa == .PBXFileReference)
         return fileref
-        // return FileReference.lastKnownFileType(.sourcecodeswift)
-        //     .path(path.string)
-        //     .sourceTree(.group)
-        //     .fileEncodings("4")
-        //     .build()
     }
 }
 

--- a/Sources/PBXProj/FileReference.swift
+++ b/Sources/PBXProj/FileReference.swift
@@ -29,6 +29,9 @@ final public class FileReference: IsaObject, ObjectsReferencing {
         case path
         case sourceTree
     }
+    enum OptionalStringField: String {
+        case name
+    }
     public let object: Object
     public let objects: Object
     public init(object: Object, objects: Object) {

--- a/Sources/PBXProj/FileReference.swift
+++ b/Sources/PBXProj/FileReference.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import AsciiPlistParser
+import PathKit
 
 public enum FileType: String {
     case xcconfig = "text.xcconfig"
@@ -20,14 +21,21 @@ public enum FileType: String {
     case wrapperapplication = "wrapper.application"
 }
 
+public enum SourceTree: String {
+    case group = "\"<group>\""
+    case builtProductsDir = "BUILT_PRODUCTS_DIR"
+}
+
 final public class FileReference: IsaObject, ObjectsReferencing {
     enum OptionalRawRepresentableField: String {
         case lastKnownFileType
         case explicitFileType
     }
+    enum RawRepresentableField: String {
+        case sourceTree
+    }
     enum StringField: String {
         case path
-        case sourceTree
     }
     enum OptionalStringField: String {
         case name
@@ -47,10 +55,18 @@ extension FileReference {
     subscript(field: OptionalRawRepresentableField) -> FileType? {
         set(newValue) {
             if let keyref = object.keyRef(for: field.rawValue) {
-                object[keyref] = newValue?.rawValue
+                if let rawValue = newValue?.rawValue {
+                    let existing = object[keyref] as! StringValue
+                    existing.value = rawValue
+                    object[keyref] = existing
+                } else {
+                    object[keyref] = nil
+                }
             } else {
-                let keyref = KeyRef(value: field.rawValue, annotation: nil)
-                object[keyref] = newValue?.rawValue
+                if let rawValue = newValue?.rawValue {
+                    let keyref = KeyRef(value: field.rawValue, annotation: nil)
+                    object[keyref] = StringValue(value: rawValue, annotation: nil)
+                }
             }
         }
         get {
@@ -60,15 +76,59 @@ extension FileReference {
             return FileType(rawValue: rawValue)
         }
     }
+    subscript(field: RawRepresentableField) -> SourceTree? {
+        set(newValue) {
+            if let keyref = object.keyRef(for: field.rawValue) {
+                if let rawValue = newValue?.rawValue {
+                    let existing = object[keyref] as! StringValue
+                    existing.value = rawValue
+                    object[keyref] = existing
+                } else {
+                    object[keyref] = nil
+                }
+            } else {
+                if let rawValue = newValue?.rawValue {
+                    let keyref = KeyRef(value: field.rawValue, annotation: nil)
+                    object[keyref] = StringValue(value: rawValue, annotation: nil)
+                }
+            }
+        }
+        get {
+            guard let rawValue = object.string(for: field.rawValue) else {
+                return nil
+            }
+            return SourceTree(rawValue: rawValue)
+        }
+    }
     public var lastKnownFileType: LastKnownFileType? {
         return self[.lastKnownFileType]
     }
     public var explicitFileType: ExplicitFileType? {
         return self[.explicitFileType]
     }
+    public var sourceTree: SourceTree? {
+        return self[.sourceTree]
+    }
 }
 
-// MARK: Useful API
+extension FileReference {
+    static func create(path: Path) -> FileReference {
+        let fileref = FileReference(object: [:], objects: [:])
+        fileref[.lastKnownFileType] = .sourcecodeswift
+        fileref[.sourceTree] = .group
+        fileref[.path] = path.string
+        fileref.object["isa"] = StringValue(value: IsaType.PBXFileReference.rawValue, annotation: nil)
+        assert(fileref.isa == .PBXFileReference)
+        return fileref
+        // return FileReference.lastKnownFileType(.sourcecodeswift)
+        //     .path(path.string)
+        //     .sourceTree(.group)
+        //     .fileEncodings("4")
+        //     .build()
+    }
+}
+
+// MARK: Public API
 extension FileReference {
     public var fullPath: String {
         let path = findPaths(to: self, objects: objects) + [self.path]

--- a/Sources/PBXProj/Functions.swift
+++ b/Sources/PBXProj/Functions.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 import AsciiPlistParser
-import RandomKit
 
 func findPaths(to fileref: FileReference, objects: Object) -> [String] {
     let id = objects.filter { ($1 as? Object) == fileref.object }.map { $0.0.value }[0]

--- a/Sources/PBXProj/Functions.swift
+++ b/Sources/PBXProj/Functions.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import AsciiPlistParser
+import RandomKit
 
 func findPaths(to fileref: FileReference, objects: Object) -> [String] {
     let id = objects.filter { ($1 as? Object) == fileref.object }.map { $0.0.value }[0]
@@ -27,4 +28,18 @@ func _findPaths(to id: String, objects: Object) -> [String] {
         }
     }
     return []
+}
+
+extension Array {
+    func take(_ length: Int) -> Array {
+        if count <= length {
+            return self
+        } else {
+            return self[0..<length].map { $0 }
+        }
+    }
+}
+
+func generateNewId() -> String {
+    return UUID().uuidString.characters.map { String($0) } .filter { $0 != "-" }.take(24).joined()
 }

--- a/Sources/PBXProj/Group.swift
+++ b/Sources/PBXProj/Group.swift
@@ -70,5 +70,6 @@ extension Group {
         }
     }
     func _addGroup(path: Path, copyItemsIfNeeded: Bool = false, behaviorForAddedFolders: BehaviorForAddedFolders = .createGroups, addToTargets targets: [Target] = []) throws {
+        // TODO: not implemented yet
     }
 }

--- a/Sources/PBXProj/Group.swift
+++ b/Sources/PBXProj/Group.swift
@@ -52,8 +52,10 @@ extension Group {
     func _addFileReference(path: Path, copyItemsIfNeeded: Bool = false, behaviorForAddedFolders: BehaviorForAddedFolders = .createGroups, addToTargets targets: [Target] = []) throws {
         let fileref = FileReference.create(path: path)
         let filerefId = generateNewId()
-        objects[filerefId] = fileref.object
-        children.append(StringValue(value: filerefId, annotation: path.components.last!))
+        let filename = path.components.last!
+        let keyref = KeyRef(value: filerefId, annotation: filename)
+        objects[keyref] = fileref.object
+        children.append(StringValue(value: filerefId, annotation: filename))
     }
     func _addGroup(path: Path, copyItemsIfNeeded: Bool = false, behaviorForAddedFolders: BehaviorForAddedFolders = .createGroups, addToTargets targets: [Target] = []) throws {
     }

--- a/Sources/PBXProj/Group.swift
+++ b/Sources/PBXProj/Group.swift
@@ -53,9 +53,21 @@ extension Group {
         let fileref = FileReference.create(path: path)
         let filerefId = generateNewId()
         let filename = path.components.last!
-        let keyref = KeyRef(value: filerefId, annotation: filename)
-        objects[keyref] = fileref.object
-        children.append(StringValue(value: filerefId, annotation: filename))
+        let fkeyref = KeyRef(value: filerefId, annotation: filename)
+        objects[fkeyref] = fileref.object
+        children.append(fkeyref)
+        if targets.isEmpty {
+            return
+        }
+        let buildfile = BuildFile.create(fileRef: filerefId).anyIsaObject
+        let buildfileId = generateNewId()
+        let annotation = "\(filename) in Sources"
+        let bkeyref = KeyRef(value: buildfileId, annotation: annotation)
+        for target in targets {
+            let sourcesBuildPhase = target.buildPhases.filter { $0.isa == .PBXSourcesBuildPhase }[0]
+            sourcesBuildPhase.files.append(bkeyref)
+            objects[bkeyref] = buildfile.object
+        }
     }
     func _addGroup(path: Path, copyItemsIfNeeded: Bool = false, behaviorForAddedFolders: BehaviorForAddedFolders = .createGroups, addToTargets targets: [Target] = []) throws {
     }

--- a/Sources/PBXProj/Group.swift
+++ b/Sources/PBXProj/Group.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import AsciiPlistParser
+import PathKit
 
 final public class Group: IsaObject, ObjectsReferencing {
     enum ArrayField: String {
@@ -25,5 +26,35 @@ final public class Group: IsaObject, ObjectsReferencing {
     public init(object: Object, objects: Object) {
         self.object = object
         self.objects = objects
+    }
+}
+
+// MARK: Public API
+
+extension Group {
+    public enum BehaviorForAddedFolders {
+        case createGroups, createFolderReference
+    }
+
+    public func addFiles(paths: [String], copyItemsIfNeeded: Bool = false, behaviorForAddedFolders: BehaviorForAddedFolders = .createGroups, addToTargets targets: [Target] = []) throws {
+        for path in paths {
+            try addFile(path: Path(path), copyItemsIfNeeded: copyItemsIfNeeded, behaviorForAddedFolders: behaviorForAddedFolders, addToTargets: targets)
+        }
+    }
+    public func addFile(path: Path, copyItemsIfNeeded: Bool = false, behaviorForAddedFolders: BehaviorForAddedFolders = .createGroups, addToTargets targets: [Target] = []) throws {
+        if path.isDirectory {
+            try _addGroup(path: path, copyItemsIfNeeded: copyItemsIfNeeded, behaviorForAddedFolders: behaviorForAddedFolders, addToTargets: targets)
+        } else {
+            try _addFileReference(path: path, copyItemsIfNeeded: copyItemsIfNeeded, behaviorForAddedFolders: behaviorForAddedFolders, addToTargets: targets)
+        }
+    }
+
+    func _addFileReference(path: Path, copyItemsIfNeeded: Bool = false, behaviorForAddedFolders: BehaviorForAddedFolders = .createGroups, addToTargets targets: [Target] = []) throws {
+        let fileref = FileReference.create(path: path)
+        let filerefId = generateNewId()
+        objects[filerefId] = fileref.object
+        children.append(StringValue(value: filerefId, annotation: path.components.last!))
+    }
+    func _addGroup(path: Path, copyItemsIfNeeded: Bool = false, behaviorForAddedFolders: BehaviorForAddedFolders = .createGroups, addToTargets targets: [Target] = []) throws {
     }
 }

--- a/Sources/PBXProj/Pbxproj.swift
+++ b/Sources/PBXProj/Pbxproj.swift
@@ -59,6 +59,10 @@ extension Pbxproj {
         }
     }
 
+    public func target(named: String) -> Target? {
+        return targets.filter { $0.name == named }.first
+    }
+
     public func fileReferences() -> [FileReference] {
         return objects.flatMap { $0.1 as? Object }.filter { $0.isa == .PBXFileReference }.map { FileReference(object: $0, objects: objects) }
     }

--- a/Sources/PBXProj/Pbxproj.swift
+++ b/Sources/PBXProj/Pbxproj.swift
@@ -54,13 +54,29 @@ public class Pbxproj: AutoPbxSubscript, ObjectsReferencing {
 // MARK: Alias Access API
 extension Pbxproj {
     public var targets: [Target] {
-        get {
-            return rootObject.targets
-        }
+        return rootObject.targets
+    }
+    public func buildFiles() -> [BuildFile] {
+        return objects.flatMap { $0.1 as? Object }.filter { $0.isa == .PBXBuildFile }.map { BuildFile(object: $0, objects: objects) }
     }
 
     public func target(named: String) -> Target? {
         return targets.filter { $0.name == named }.first
+    }
+
+    public func buildFile(named: String) -> BuildFile? {
+        return buildFiles().flatMap {
+            guard let o = objects.object(for: $0.fileRef) else {
+                return nil
+            }
+            if o.isa == .PBXFileReference {
+                let fileref = FileReference(object: o, objects: objects)
+                return (fileref.name == named || fileref.path == named) ? $0 : nil
+            } else {
+                // TODO: Handle PBXVariantGroup and XCVersionGroup
+                return nil
+            }
+        }.first
     }
 
     public func fileReferences() -> [FileReference] {

--- a/Sources/PBXProj/Pbxproj.swift
+++ b/Sources/PBXProj/Pbxproj.swift
@@ -58,4 +58,20 @@ extension Pbxproj {
             return rootObject.targets
         }
     }
+
+    public func fileReferences() -> [FileReference] {
+        return objects.flatMap { $0.1 as? Object }.filter { $0.isa == .PBXFileReference }.map { FileReference(object: $0, objects: objects) }
+    }
+
+    public func groups() -> [Group] {
+        return objects.flatMap { $0.1 as? Object }.filter { $0.isa == .PBXGroup }.map { Group(object: $0, objects: objects) }
+    }
+
+    public func fileReferences(named: String) -> [FileReference] {
+        return fileReferences().filter { $0.path == named || $0.name == named }
+    }
+
+    public func groups(named: String) -> [Group] {
+        return groups().filter { $0.path == named || $0.name == named }
+    }
 }

--- a/Sources/PBXProj/Project.swift
+++ b/Sources/PBXProj/Project.swift
@@ -6,7 +6,6 @@ public class RootObject: IsaObject, ObjectsReferencing {
         case compatibilityVersion
         case developmentRegion
         case hasScannedForEncodings
-        case mainGroup
         case productRefGroup // Can be represented as Object
         case projectDirPath
     }
@@ -22,6 +21,9 @@ public class RootObject: IsaObject, ObjectsReferencing {
     }
     enum ObjectsReferencingArrayField {
         case targets
+    }
+    enum GroupReferencingField {
+        case mainGroup
     }
     public let object: Object
     public let objects: Object

--- a/Sources/PBXProj/Project.swift
+++ b/Sources/PBXProj/Project.swift
@@ -19,7 +19,7 @@ public class RootObject: IsaObject, ObjectsReferencing {
     enum OptionalStringField: String {
         case projectRoot
     }
-    enum ObjectsReferencingArrayField {
+    enum ObjectReferencingArrayField {
         case targets
     }
     enum GroupReferencingField {

--- a/Sources/PBXProj/Target.swift
+++ b/Sources/PBXProj/Target.swift
@@ -35,6 +35,9 @@ final public class Target: IsaObject, ObjectsReferencing {
     enum ObjectsReferencingField: String {
         case buildConfigurationList
     }
+    enum ObjectReferencingArrayField: String {
+        case buildPhases
+    }
     public let object: Object
     public let objects: Object
     public init(object: Object, objects: Object) {

--- a/Sources/PBXProj/Types.swift
+++ b/Sources/PBXProj/Types.swift
@@ -53,3 +53,13 @@ extension IsaObject {
         set(newValue) { object["isa"] = newValue.rawValue }
     }
 }
+
+public class AnyIsaObject: IsaObject, ObjectsReferencing {
+    public let object: Object
+    public let objects: Object
+    public init(object: Object, objects: Object) {
+        assert(object.isa != nil)
+        self.object = object
+        self.objects = objects
+    }
+}

--- a/Sources/PBXProj/Types.swift
+++ b/Sources/PBXProj/Types.swift
@@ -31,16 +31,20 @@ public protocol AutoPbxSubscript {
 public protocol ObjectsReferencing: AutoPbxSubscript {
     var objects: Object { get }
     func objectTuple(for id: String) -> (Object, Object)
+    var anyIsaObject: AnyIsaObject { get }
 }
 
 extension ObjectsReferencing {
     public func objectTuple(for id: String) -> (Object, Object) {
         return (objects.object(for: id)!, objects)
     }
+    public var anyIsaObject: AnyIsaObject {
+        return AnyIsaObject(object: object, objects: objects)
+    }
 }
 
 public protocol IsaObject: class, AutoPbxSubscript {
-    var isa: IsaType { get }
+    var isa: IsaType { get set }
 }
 
 extension IsaObject {

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -3,16 +3,22 @@
 
 
 import XCTest
+extension FileReferenceTests {
+  static var allTests: [(String, (FileReferenceTests) -> () throws -> Void)] = [
+    ("testFileReference", testFileReference),
+    ("testAddFileReference", testAddFileReference),
+  ]
+}
 extension PbxprojTests {
   static var allTests: [(String, (PbxprojTests) -> () throws -> Void)] = [
     ("testPbxproj", testPbxproj),
     ("testModification", testModification),
     ("testBuildSettings", testBuildSettings),
-    ("testFileReference", testFileReference),
   ]
 }
 
 XCTMain([
+  testCase(FileReferenceTests.allTests),
   testCase(PbxprojTests.allTests),
 ])
 

--- a/Tests/PbxprojTests/FileReferenceTests.swift
+++ b/Tests/PbxprojTests/FileReferenceTests.swift
@@ -39,12 +39,12 @@ class FileReferenceTests: XCTestCase {
         let appTarget = pbxproj.target(named: "SingleViewApplication")!
         let group = pbxproj.groups(named: "SingleViewApplication")[0]
         try! group.addFiles(paths: ["./hoge/foo/Bar.swift"], copyItemsIfNeeded: false, behaviorForAddedFolders: .createGroups, addToTargets: [appTarget])
-        let fileref: FileReference = pbxproj.fileReferences(named: "./hoge/foo/Bar.swift")[0]
+        let fileref: FileReference = pbxproj.fileReferences(named: "hoge/foo/Bar.swift")[0]
         XCTAssertEqual(fileref.isa, .PBXFileReference)
         XCTAssertEqual(fileref.explicitFileType, nil)
         XCTAssertEqual(fileref.lastKnownFileType, .sourcecodeswift)
         XCTAssertEqual(fileref.path, "hoge/foo/Bar.swift")
         XCTAssertEqual(fileref.sourceTree, .group)
-        XCTAssertEqual(fileref.fullPath, "SingleViewApplication/AppDelegate.swift")
+        XCTAssertEqual(fileref.fullPath, "SingleViewApplication/hoge/foo/Bar.swift")
     }
 }

--- a/Tests/PbxprojTests/FileReferenceTests.swift
+++ b/Tests/PbxprojTests/FileReferenceTests.swift
@@ -47,5 +47,10 @@ class FileReferenceTests: XCTestCase {
         XCTAssertEqual(fileref.sourceTree, .group)
         XCTAssertEqual(fileref.fullPath, "SingleViewApplication/hoge/foo/Bar.swift")
         XCTAssert(pbxproj.string().contains("/* Bar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Bar.swift; path = hoge/foo/Bar.swift; sourceTree = \"<group>\"; };"))
+        let fileRefId = pbxproj.objects.flatMap { ($1 as? Object) == fileref.object ? $0.value : nil }[0]
+        let buildFile: BuildFile = pbxproj.buildFile(named: "Bar.swift")!
+        XCTAssertEqual(buildFile.isa, .PBXBuildFile)
+        XCTAssertEqual(buildFile.fileRef, fileRefId)
+        XCTAssert(pbxproj.string().contains("/* Bar.swift in Sources */ = {isa = PBXBuildFile; fileRef ="))
     }
 }

--- a/Tests/PbxprojTests/FileReferenceTests.swift
+++ b/Tests/PbxprojTests/FileReferenceTests.swift
@@ -47,7 +47,7 @@ class FileReferenceTests: XCTestCase {
         XCTAssertEqual(fileref.sourceTree, .group)
         XCTAssertEqual(fileref.fullPath, "SingleViewApplication/hoge/foo/Bar.swift")
         XCTAssert(pbxproj.string().contains("/* Bar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Bar.swift; path = hoge/foo/Bar.swift; sourceTree = \"<group>\"; };"))
-        let fileRefId = pbxproj.objects.flatMap { ($1 as? Object) == fileref.object ? $0.value : nil }[0]
+        let fileRefId = pbxproj.objects.key(for: fileref.object)!
         let buildFile: BuildFile = pbxproj.buildFile(named: "Bar.swift")!
         XCTAssertEqual(buildFile.isa, .PBXBuildFile)
         XCTAssertEqual(buildFile.fileRef, fileRefId)

--- a/Tests/PbxprojTests/FileReferenceTests.swift
+++ b/Tests/PbxprojTests/FileReferenceTests.swift
@@ -25,7 +25,7 @@ class FileReferenceTests: XCTestCase {
         XCTAssertEqual(fileref.explicitFileType, nil)
         XCTAssertEqual(fileref.lastKnownFileType, .sourcecodeswift)
         XCTAssertEqual(fileref.path, "AppDelegate.swift")
-        XCTAssertEqual(fileref.sourceTree, "\"<group>\"")
+        XCTAssertEqual(fileref.sourceTree, .group)
         XCTAssertEqual(fileref.fullPath, "SingleViewApplication/AppDelegate.swift")
 
         // TODO: Needs proper test
@@ -36,17 +36,15 @@ class FileReferenceTests: XCTestCase {
     }
 
     func testAddFileReference() {
-//        let group: Group = Group.create(path: "hoge/foo", group)
-//        group.children.appendChild("Bar.swift")
-//        pbxproj.addFileReference(path: "hoge/foo/Bar.swift", group: "model/hage/uge/Bar.swift")
+        let appTarget = pbxproj.target(named: "SingleViewApplication")!
         let group = pbxproj.groups(named: "SingleViewApplication")[0]
-        group.addFiles(paths: ["hoge/foo/Bar.swift"], copyItemsIfNeeded: false, behaviorForAddedFolders: .createGroups, addToTargets: ["App", "AppTests"], destinationGroup: group)
-        let fileref: FileReference = pbxproj.fileReferences(named: "Bar.swift")[0]
+        try! group.addFiles(paths: ["./hoge/foo/Bar.swift"], copyItemsIfNeeded: false, behaviorForAddedFolders: .createGroups, addToTargets: [appTarget])
+        let fileref: FileReference = pbxproj.fileReferences(named: "./hoge/foo/Bar.swift")[0]
         XCTAssertEqual(fileref.isa, .PBXFileReference)
         XCTAssertEqual(fileref.explicitFileType, nil)
         XCTAssertEqual(fileref.lastKnownFileType, .sourcecodeswift)
         XCTAssertEqual(fileref.path, "hoge/foo/Bar.swift")
-        XCTAssertEqual(fileref.sourceTree, "\"<group>\"")
+        XCTAssertEqual(fileref.sourceTree, .group)
         XCTAssertEqual(fileref.fullPath, "SingleViewApplication/AppDelegate.swift")
     }
 }

--- a/Tests/PbxprojTests/FileReferenceTests.swift
+++ b/Tests/PbxprojTests/FileReferenceTests.swift
@@ -7,6 +7,8 @@
 //
 
 import XCTest
+import AsciiPlistParser
+@testable import Pbxproj
 
 class FileReferenceTests: XCTestCase {
 
@@ -37,10 +39,7 @@ class FileReferenceTests: XCTestCase {
 //        let group: Group = Group.create(path: "hoge/foo", group)
 //        group.children.appendChild("Bar.swift")
 //        pbxproj.addFileReference(path: "hoge/foo/Bar.swift", group: "model/hage/uge/Bar.swift")
-        guard let group = pbxproj.group(named: "SingleViewApplication") else {
-            XCTFail()
-            return
-        }
+        let group = pbxproj.groups(named: "SingleViewApplication")[0]
         group.addFiles(paths: ["hoge/foo/Bar.swift"], copyItemsIfNeeded: false, behaviorForAddedFolders: .createGroups, addToTargets: ["App", "AppTests"], destinationGroup: group)
         let fileref: FileReference = pbxproj.fileReferences(named: "Bar.swift")[0]
         XCTAssertEqual(fileref.isa, .PBXFileReference)

--- a/Tests/PbxprojTests/FileReferenceTests.swift
+++ b/Tests/PbxprojTests/FileReferenceTests.swift
@@ -1,0 +1,53 @@
+//
+//  FileReferenceTests.swift
+//  Pbxproj
+//
+//  Created by Toshihiro suzuki on 2017/05/16.
+//
+//
+
+import XCTest
+
+class FileReferenceTests: XCTestCase {
+
+    var pbxproj: Pbxproj!
+    override func setUp() {
+        super.setUp()
+        self.pbxproj = _pbxproj()
+    }
+
+    func testFileReference() {
+        let objects = pbxproj.objects
+        let fileref = FileReference(object: pbxproj.objects.object(for: "1F88C5871EB47C3C002A5302")!, objects: objects) // AppDelegate.swift
+        XCTAssertEqual(fileref.isa, .PBXFileReference)
+        XCTAssertEqual(fileref.explicitFileType, nil)
+        XCTAssertEqual(fileref.lastKnownFileType, .sourcecodeswift)
+        XCTAssertEqual(fileref.path, "AppDelegate.swift")
+        XCTAssertEqual(fileref.sourceTree, "\"<group>\"")
+        XCTAssertEqual(fileref.fullPath, "SingleViewApplication/AppDelegate.swift")
+
+        // TODO: Needs proper test
+        XCTAssertEqual(
+            pbxproj.targets[0].buildConfigurationList.buildConfigurations[0].baseConfigurationReference?.fullPath,
+           nil
+        )
+    }
+
+    func testAddFileReference() {
+//        let group: Group = Group.create(path: "hoge/foo", group)
+//        group.children.appendChild("Bar.swift")
+//        pbxproj.addFileReference(path: "hoge/foo/Bar.swift", group: "model/hage/uge/Bar.swift")
+        guard let group = pbxproj.group(named: "SingleViewApplication") else {
+            XCTFail()
+            return
+        }
+        group.addFiles(paths: ["hoge/foo/Bar.swift"], copyItemsIfNeeded: false, behaviorForAddedFolders: .createGroups, addToTargets: ["App", "AppTests"], destinationGroup: group)
+        let fileref: FileReference = pbxproj.fileReferences(named: "Bar.swift")[0]
+        XCTAssertEqual(fileref.isa, .PBXFileReference)
+        XCTAssertEqual(fileref.explicitFileType, nil)
+        XCTAssertEqual(fileref.lastKnownFileType, .sourcecodeswift)
+        XCTAssertEqual(fileref.path, "hoge/foo/Bar.swift")
+        XCTAssertEqual(fileref.sourceTree, "\"<group>\"")
+        XCTAssertEqual(fileref.fullPath, "SingleViewApplication/AppDelegate.swift")
+    }
+}

--- a/Tests/PbxprojTests/FileReferenceTests.swift
+++ b/Tests/PbxprojTests/FileReferenceTests.swift
@@ -46,5 +46,6 @@ class FileReferenceTests: XCTestCase {
         XCTAssertEqual(fileref.path, "hoge/foo/Bar.swift")
         XCTAssertEqual(fileref.sourceTree, .group)
         XCTAssertEqual(fileref.fullPath, "SingleViewApplication/hoge/foo/Bar.swift")
+        XCTAssert(pbxproj.string().contains("/* Bar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Bar.swift; path = hoge/foo/Bar.swift; sourceTree = \"<group>\"; };"))
     }
 }

--- a/Tests/PbxprojTests/Helper.swift
+++ b/Tests/PbxprojTests/Helper.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Pbxproj
 
 func pathForFixture(fileName: String) -> String {
     #if Xcode
@@ -7,4 +8,13 @@ func pathForFixture(fileName: String) -> String {
     #else
         return "Tests/AsciiPlistParserTests/Fixtures/\(fileName)"
     #endif
+}
+
+func _pbxproj() -> Pbxproj {
+    #if Xcode
+        let path = pathForFixture(fileName: "test.pbxproj")
+    #else
+        let path = pathForFixture(fileName: "Xcode/8.3.2/SingleViewApplication/SingleViewApplication.xcodeproj/project.pbxproj")
+    #endif
+    return try! Pbxproj(path: path)
 }

--- a/Tests/PbxprojTests/PbxprojTests.swift
+++ b/Tests/PbxprojTests/PbxprojTests.swift
@@ -6,12 +6,7 @@ class PbxprojTests: XCTestCase {
     var pbxproj: Pbxproj!
     override func setUp() {
         super.setUp()
-        #if Xcode
-            let path = pathForFixture(fileName: "test.pbxproj")
-        #else
-            let path = pathForFixture(fileName: "Xcode/8.3.2/SingleViewApplication/SingleViewApplication.xcodeproj/project.pbxproj")
-        #endif
-        pbxproj = try! Pbxproj(path: path)
+        self.pbxproj = _pbxproj()
     }
     func testPbxproj() {
         XCTAssertEqual(pbxproj.archiveVersion, "1")
@@ -42,22 +37,5 @@ class PbxprojTests: XCTestCase {
             }
         }
         XCTAssert(pbxproj.string().contains("jp.toshi0383.HelloWorld"))
-    }
-
-    func testFileReference() {
-        let objects = pbxproj.objects
-        let fileref = FileReference(object: pbxproj.objects.object(for: "1F88C5871EB47C3C002A5302")!, objects: objects) // AppDelegate.swift
-        XCTAssertEqual(fileref.isa, .PBXFileReference)
-        XCTAssertEqual(fileref.explicitFileType, nil)
-        XCTAssertEqual(fileref.lastKnownFileType, .sourcecodeswift)
-        XCTAssertEqual(fileref.path, "AppDelegate.swift")
-        XCTAssertEqual(fileref.sourceTree, "\"<group>\"")
-        XCTAssertEqual(fileref.fullPath, "SingleViewApplication/AppDelegate.swift")
-
-        // TODO: Needs proper test
-        XCTAssertEqual(
-            pbxproj.targets[0].buildConfigurationList.buildConfigurations[0].baseConfigurationReference?.fullPath,
-           nil
-        )
     }
 }


### PR DESCRIPTION
Introduces adding new file API which is equivalent to Xcode's `Add Files to MyApp...`.

Usage:
```swift
let appTarget = pbxproj.target(named: "SingleViewApplication")!
let group = pbxproj.groups(named: "SingleViewApplication")[0]
try! group.addFiles(paths: ["./hoge/foo/Bar.swift"], copyItemsIfNeeded: false, behaviorForAddedFolders: .createGroups, addToTargets: [appTarget])
```