### PR TITLE
Support to Add a folder as a group

### DIFF
--- a/Resources/SourceryTemplates/AutoPbxSubscript.stencil
+++ b/Resources/SourceryTemplates/AutoPbxSubscript.stencil
@@ -55,7 +55,8 @@ extension {{ type.name }} {
         }
     }
     public var {{ c.name }}: {{ c.name|upperFirst }} {
-        return self[.{{ c.name }}]
+        set(newValue) { self[.{{ c.name }}] = newValue }
+        get { return self[.{{ c.name }}] }
     }
     {% endfor %}
     {% endif %}

--- a/Sources/PBXProj/AutoPbxSubscript.out.swift
+++ b/Sources/PBXProj/AutoPbxSubscript.out.swift
@@ -237,7 +237,8 @@ extension FileReference {
         }
     }
     public var sourceTree: SourceTree {
-        return self[.sourceTree]
+        set(newValue) { self[.sourceTree] = newValue }
+        get { return self[.sourceTree] }
     }
 
 
@@ -337,7 +338,8 @@ extension Group {
         }
     }
     public var sourceTree: SourceTree {
-        return self[.sourceTree]
+        set(newValue) { self[.sourceTree] = newValue }
+        get { return self[.sourceTree] }
     }
 
 
@@ -678,7 +680,8 @@ extension Target {
         }
     }
     public var productType: ProductType {
-        return self[.productType]
+        set(newValue) { self[.productType] = newValue }
+        get { return self[.productType] }
     }
 
 

--- a/Sources/PBXProj/Errors.swift
+++ b/Sources/PBXProj/Errors.swift
@@ -1,5 +1,5 @@
 import Foundation
 
 enum AddFilesError: Error {
-    case filesNotFound
+    case fileNotExist(String)
 }

--- a/Sources/PBXProj/FileReference.swift
+++ b/Sources/PBXProj/FileReference.swift
@@ -19,6 +19,31 @@ public enum FileType: String {
     case wrappercfbundle = "wrapper.cfbundle"
     case textplistxml = "text.plist.xml"
     case wrapperapplication = "wrapper.application"
+    public init?(filename: String) {
+        guard let ext = Path(filename).extension else {
+            return nil
+        }
+        switch ext {
+        case "xcconfig":
+            self = .xcconfig
+        case "swift":
+            self = .sourcecodeswift
+        case "storyboard":
+            self = .filestoryboard
+        case "xcassets":
+            self = .folderassetcatalog
+        case "xcdatamodeld":
+            self = .wrapperxcdatamodel
+        case "plist":
+            self = .textplistxml
+        case "bundle":
+            self = .wrappercfbundle
+        case "app":
+            self = .wrapperapplication
+        default:
+            return nil
+        }
+    }
 }
 
 public enum SourceTree: String {
@@ -52,7 +77,7 @@ final public class FileReference: IsaObject, ObjectsReferencing {
 extension FileReference {
     static func create(path: Path) -> FileReference {
         let fileref = FileReference(object: [:], objects: [:])
-        fileref[.lastKnownFileType] = .sourcecodeswift
+        fileref[.lastKnownFileType] = FileType(filename: path.lastComponent)!
         fileref[.sourceTree] = .group
         fileref[.fileEncoding] = "4"
         let filename = path.components.last!

--- a/Sources/PBXProj/FileReference.swift
+++ b/Sources/PBXProj/FileReference.swift
@@ -57,7 +57,7 @@ extension FileReference {
         fileref[.fileEncoding] = "4"
         let filename = path.components.last!
         fileref[.name] = filename
-        fileref[.path] = path.normalize().string
+        fileref[.path] = path.string
         fileref.object["isa"] = StringValue(value: IsaType.PBXFileReference.rawValue, annotation: nil)
         assert(fileref.isa == .PBXFileReference)
         return fileref

--- a/Sources/PBXProj/Functions.swift
+++ b/Sources/PBXProj/Functions.swift
@@ -13,6 +13,10 @@ func findPaths(to fileref: FileReference, objects: Object) -> [String] {
     let id = objects.filter { ($1 as? Object) == fileref.object }.map { $0.0.value }[0]
     return _findPaths(to: id, objects: objects)
 }
+func findPaths(to group: Group, objects: Object) -> [String] {
+    let id = objects.filter { ($1 as? Object) == group.object }.map { $0.0.value }[0]
+    return _findPaths(to: id, objects: objects)
+}
 func _findPaths(to id: String, objects: Object) -> [String] {
     for (k, v) in objects {
         if let o = v as? Object, let isa = o.isa, isa == .PBXGroup {

--- a/Sources/PBXProj/Group.swift
+++ b/Sources/PBXProj/Group.swift
@@ -43,6 +43,13 @@ extension Group {
 // MARK: Public API
 
 extension Group {
+    public var fullPath: String {
+        let path = findPaths(to: self, objects: objects) + [self.path!]
+        return path.joined(separator: "/")
+    }
+}
+
+extension Group {
     public enum BehaviorForAddedFolders {
         case createGroups, createFolderReference
     }
@@ -92,6 +99,7 @@ extension Group {
         let groupId = generateNewId()
         let annotation = path.lastComponent
         let gkeyref = KeyRef(value: groupId, annotation: annotation)
+        children.append(gkeyref)
         objects[gkeyref] = group.object
         // add children recursively
         try path.chdir {

--- a/Sources/PBXProj/Group.swift
+++ b/Sources/PBXProj/Group.swift
@@ -29,6 +29,17 @@ final public class Group: IsaObject, ObjectsReferencing {
     }
 }
 
+extension Group {
+    static func create(path: Path, objects: Object) -> Group {
+        let group = Group(object: [:], objects: objects)
+        group.isa = .PBXGroup
+        group.path = path.string
+        group.sourceTree = .group
+        group.children = []
+        return group
+    }
+}
+
 // MARK: Public API
 
 extension Group {
@@ -38,10 +49,13 @@ extension Group {
 
     public func addFiles(paths: [String], copyItemsIfNeeded: Bool = false, behaviorForAddedFolders: BehaviorForAddedFolders = .createGroups, addToTargets targets: [Target] = []) throws {
         for path in paths {
-            try addFile(path: Path(path), copyItemsIfNeeded: copyItemsIfNeeded, behaviorForAddedFolders: behaviorForAddedFolders, addToTargets: targets)
+            try addFile(path: Path(path).normalize(), copyItemsIfNeeded: copyItemsIfNeeded, behaviorForAddedFolders: behaviorForAddedFolders, addToTargets: targets)
         }
     }
     public func addFile(path: Path, copyItemsIfNeeded: Bool = false, behaviorForAddedFolders: BehaviorForAddedFolders = .createGroups, addToTargets targets: [Target] = []) throws {
+        guard path.exists else {
+            throw AddFilesError.fileNotExist(path.string)
+        }
         if path.isDirectory {
             try _addGroup(path: path, copyItemsIfNeeded: copyItemsIfNeeded, behaviorForAddedFolders: behaviorForAddedFolders, addToTargets: targets)
         } else {
@@ -70,6 +84,20 @@ extension Group {
         }
     }
     func _addGroup(path: Path, copyItemsIfNeeded: Bool = false, behaviorForAddedFolders: BehaviorForAddedFolders = .createGroups, addToTargets targets: [Target] = []) throws {
-        // TODO: not implemented yet
+        // TODO: support .createFolderReference
+        // TODO: support copyItemsIfNeeded
+        assert(behaviorForAddedFolders == .createGroups)
+        // add group
+        let group = Group.create(path: path, objects: objects)
+        let groupId = generateNewId()
+        let annotation = path.lastComponent
+        let gkeyref = KeyRef(value: groupId, annotation: annotation)
+        objects[gkeyref] = group.object
+        // add children recursively
+        try path.chdir {
+            for child in try Path.current.children() {
+                try group.addFile(path: Path(child.normalize().lastComponent), copyItemsIfNeeded: copyItemsIfNeeded, behaviorForAddedFolders: behaviorForAddedFolders, addToTargets: targets)
+            }
+        }
     }
 }

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -3,10 +3,11 @@
 
 
 import XCTest
-extension FileReferenceTests {
-  static var allTests: [(String, (FileReferenceTests) -> () throws -> Void)] = [
+extension FilesAndGroupsTests {
+  static var allTests: [(String, (FilesAndGroupsTests) -> () throws -> Void)] = [
     ("testFileReference", testFileReference),
-    ("testAddFileReference", testAddFileReference),
+    ("testAddAFile", testAddAFile),
+    ("testAddAFolderAsGroup", testAddAFolderAsGroup),
   ]
 }
 extension PbxprojTests {
@@ -18,7 +19,7 @@ extension PbxprojTests {
 }
 
 XCTMain([
-  testCase(FileReferenceTests.allTests),
+  testCase(FilesAndGroupsTests.allTests),
   testCase(PbxprojTests.allTests),
 ])
 

--- a/Tests/PbxprojTests/FilesAndGroupsTests.swift
+++ b/Tests/PbxprojTests/FilesAndGroupsTests.swift
@@ -64,11 +64,10 @@ class FilesAndGroupsTests: XCTestCase {
 
     func testAddAFolderAsGroup() {
         // mkdir and touch a file
-        let dir = Path("hoge/foo")
-        try! dir.mkpath()
-        let file = dir + "Bar.swift"
-        try! file.write("")
-        
+        for path in ["hoge/foo/Bar.xcconfig", "hoge/foo/Foo.xcconfig", "hoge/foo/bar/Age.xcconfig"] {
+            createPathAndFiles(path: path)
+        }
+
         // test code
         let g = pbxproj.rootObject.mainGroup
         try! g.addFiles(paths: ["./hoge/foo"], copyItemsIfNeeded: false, behaviorForAddedFolders: .createGroups, addToTargets: [])
@@ -79,20 +78,30 @@ class FilesAndGroupsTests: XCTestCase {
         }
         XCTAssertEqual(group.isa, .PBXGroup)
         XCTAssertEqual(group.path, "hoge/foo")
-        XCTAssertEqual(group.children.count, 1)
+        XCTAssertEqual(group.children.count, 3)
         XCTAssertEqual(group.sourceTree, .group)
-        guard let fileref = pbxproj.fileReferences(named: "Bar.swift").first else {
+        guard let fileref = pbxproj.fileReferences(named: "Bar.xcconfig").first else {
             XCTFail("fileReferences not found.")
             print(pbxproj.string())
             return
         }
         XCTAssertEqual(fileref.isa, .PBXFileReference)
         XCTAssertEqual(fileref.explicitFileType, nil)
-        XCTAssertEqual(fileref.lastKnownFileType, .sourcecodeswift)
-        XCTAssertEqual(fileref.path, "Bar.swift")
+        XCTAssertEqual(fileref.lastKnownFileType, .xcconfig)
+        XCTAssertEqual(fileref.path, "Bar.xcconfig")
         XCTAssertEqual(fileref.sourceTree, .group)
-        XCTAssertEqual(fileref.fullPath, "hoge/foo/Bar.swift")
-        XCTAssert(pbxproj.string().contains("/* Bar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Bar.swift; path = Bar.swift; sourceTree = \"<group>\"; };"))
+        XCTAssertEqual(fileref.fullPath, "hoge/foo/Bar.xcconfig")
+        let expected = "/* Bar.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Bar.xcconfig; path = Bar.xcconfig; sourceTree = \"<group>\"; };"
+        if pbxproj.string().contains(expected) == false {
+            XCTFail("pbxproj.string() does not contain expected string. \(expected)")
+            print(pbxproj.string())
+        }
+        guard let agefileref = pbxproj.fileReferences(named: "Age.xcconfig").first else {
+            XCTFail("fileReferences not found.")
+            print(pbxproj.string())
+            return
+        }
+        XCTAssertEqual(agefileref.fullPath, "hoge/foo/bar/Age.xcconfig")
     }
 
 }

--- a/Tests/PbxprojTests/Helper.swift
+++ b/Tests/PbxprojTests/Helper.swift
@@ -30,3 +30,10 @@ func createPathAndFiles(path: String) {
     let file = components.last!
     try! (d + file).write("")
 }
+
+func cleanup(path: String) {
+    let p = Path(path)
+    if p.exists {
+        try! p.delete()
+    }
+}

--- a/Tests/PbxprojTests/Helper.swift
+++ b/Tests/PbxprojTests/Helper.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Pbxproj
+import PathKit
 
 func pathForFixture(fileName: String) -> String {
     #if Xcode
@@ -17,4 +18,15 @@ func _pbxproj() -> Pbxproj {
         let path = "Tests/PbxprojTests/test.pbxproj"
     #endif
     return try! Pbxproj(path: path)
+}
+
+func createPathAndFiles(path: String) {
+    let components = path.components(separatedBy: "/")
+    let dir = components.dropLast()
+    let d = Path(components: dir)
+    if d.exists == false {
+        try! d.mkpath()
+    }
+    let file = components.last!
+    try! (d + file).write("")
 }

--- a/Tests/PbxprojTests/Helper.swift
+++ b/Tests/PbxprojTests/Helper.swift
@@ -14,7 +14,7 @@ func _pbxproj() -> Pbxproj {
     #if Xcode
         let path = pathForFixture(fileName: "test.pbxproj")
     #else
-        let path = pathForFixture(fileName: "Xcode/8.3.2/SingleViewApplication/SingleViewApplication.xcodeproj/project.pbxproj")
+        let path = "Tests/PbxprojTests/test.pbxproj"
     #endif
     return try! Pbxproj(path: path)
 }


### PR DESCRIPTION
## Usage
```
hoge
└── foo
    ├── Bar.xcconfig
    ├── Foo.xcconfig
    └── bar
        └── Age.xcconfig
```

```swift
// addFiles
let g = pbxproj.rootObject.mainGroup
try! g.addFiles(paths: ["./hoge/foo"], copyItemsIfNeeded: false, behaviorForAddedFolders: .createGroups, addToTargets: [])
```

This will add existing `Bar.xcconfig`, `Foo.xcconfig`, and `bar/Age.xcconfig` under new Group named `hoge/foo`.
`createFolderReference` and `copyItemsIfNeeded` is not implemented yet.