### PR TITLE
Quoted String Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
   [#4](https://github.com/toshi0383/Pbxproj/pull/4)
 
 ##### Bug Fix
+* Quoted String Support  
+  [Toshihiro Suzuki](https://github.com/toshi0383)
+  [#6](https://github.com/toshi0383/Pbxproj/pull/6)
+
 * Mutable baseConfigurationReference  
   [Toshihiro Suzuki](https://github.com/toshi0383)
   [#5](https://github.com/toshi0383/Pbxproj/pull/5)

--- a/Package.pins
+++ b/Package.pins
@@ -5,7 +5,7 @@
       "package": "AsciiPlistParser",
       "reason": null,
       "repositoryURL": "https://github.com/toshi0383/AsciiPlistParser.git",
-      "version": "0.2.2"
+      "version": "0.3.0-rc2"
     },
     {
       "package": "Clang_C",
@@ -59,7 +59,7 @@
       "package": "SourceKitten",
       "reason": null,
       "repositoryURL": "https://github.com/jpsim/SourceKitten.git",
-      "version": "0.17.4"
+      "version": "0.17.6"
     },
     {
       "package": "Sourcery",

--- a/Resources/SourceryTemplates/AutoPbxSubscript.stencil
+++ b/Resources/SourceryTemplates/AutoPbxSubscript.stencil
@@ -51,8 +51,7 @@ extension {{ type.name }} {
             if let keyref = object.keyRef(for: field.rawValue) {
                 if let rawValue = newValue?.rawValue {
                     let existing = object[keyref] as! StringValue
-                    existing.value = rawValue
-                    object[keyref] = existing
+                    object[keyref] = existing.update(value: rawValue)
                 } else {
                     object[keyref] = nil
                 }
@@ -76,14 +75,35 @@ extension {{ type.name }} {
     }
     {% endfor %}
     {% endif %}
+    {% if t.name|hasSuffix:".StringValueField" %}
+    {% for c in t.cases %}
+    subscript(field: StringValueField) -> {{ c.name|upperFirst }} {
+        set(newValue) {
+            if let keyref = object.keyRef(for: field.rawValue) {
+                object[keyref] = newValue.rawValue
+            } else {
+                let keyref = KeyRef(value: field.rawValue, annotation: nil)
+                object[keyref] = newValue.rawValue
+            }
+        }
+        get {
+            let rawValue = object.stringValue(for: field.rawValue)!
+            return {{ c.name|upperFirst }}(rawValue: rawValue)!
+        }
+    }
+    public var {{ c.name }}: {{ c.name|upperFirst }} {
+        set(newValue) { self[.{{ c.name }}] = newValue }
+        get { return self[.{{ c.name }}] }
+    }
+    {% endfor %}
+    {% endif %}
     {% if t.name|hasSuffix:".RawRepresentableField" %}
     {% for c in t.cases %}
     subscript(field: RawRepresentableField) -> {{ c.name|upperFirst }} {
         set(newValue) {
             if let keyref = object.keyRef(for: field.rawValue) {
                 let existing = object[keyref] as! StringValue
-                existing.value = newValue.rawValue
-                object[keyref] = existing
+                object[keyref] = existing.update(value: newValue.rawValue)
             } else {
                 let keyref = KeyRef(value: field.rawValue, annotation: nil)
                 object[keyref] = StringValue(value: newValue.rawValue, annotation: nil)
@@ -105,8 +125,7 @@ extension {{ type.name }} {
         set(newValue) {
             if let keyref = object.keyRef(for: field.rawValue) {
                 let existing = object[keyref] as! StringValue
-                existing.value = newValue
-                object[keyref] = existing
+                object[keyref] = existing.update(value: newValue)
             } else {
                 let keyref = KeyRef(value: field.rawValue, annotation: nil)
                 let stringValue = StringValue(value: newValue, annotation: nil)
@@ -152,8 +171,7 @@ extension {{ type.name }} {
             if let keyref = object.keyRef(for: field.rawValue) {
                 if let newValue = newValue {
                     let existing = object[keyref] as! StringValue
-                    existing.value = newValue
-                    object[keyref] = existing
+                    object[keyref] = existing.update(value: newValue)
                 } else {
                     object[keyref] = nil
                 }

--- a/Sources/Pbxproj/AutoPbxSubscript.out.swift
+++ b/Sources/Pbxproj/AutoPbxSubscript.out.swift
@@ -13,8 +13,7 @@ extension BuildConfiguration {
         set(newValue) {
             if let keyref = object.keyRef(for: field.rawValue) {
                 let existing = object[keyref] as! StringValue
-                existing.value = newValue
-                object[keyref] = existing
+                object[keyref] = existing.update(value: newValue)
             } else {
                 let keyref = KeyRef(value: field.rawValue, annotation: nil)
                 let stringValue = StringValue(value: newValue, annotation: nil)
@@ -80,8 +79,7 @@ extension BuildConfigurationList {
             if let keyref = object.keyRef(for: field.rawValue) {
                 if let newValue = newValue {
                     let existing = object[keyref] as! StringValue
-                    existing.value = newValue
-                    object[keyref] = existing
+                    object[keyref] = existing.update(value: newValue)
                 } else {
                     object[keyref] = nil
                 }
@@ -108,8 +106,7 @@ extension BuildConfigurationList {
         set(newValue) {
             if let keyref = object.keyRef(for: field.rawValue) {
                 let existing = object[keyref] as! StringValue
-                existing.value = newValue
-                object[keyref] = existing
+                object[keyref] = existing.update(value: newValue)
             } else {
                 let keyref = KeyRef(value: field.rawValue, annotation: nil)
                 let stringValue = StringValue(value: newValue, annotation: nil)
@@ -133,8 +130,7 @@ extension BuildFile {
         set(newValue) {
             if let keyref = object.keyRef(for: field.rawValue) {
                 let existing = object[keyref] as! StringValue
-                existing.value = newValue
-                object[keyref] = existing
+                object[keyref] = existing.update(value: newValue)
             } else {
                 let keyref = KeyRef(value: field.rawValue, annotation: nil)
                 let stringValue = StringValue(value: newValue, annotation: nil)
@@ -158,8 +154,7 @@ extension BuildPhase {
         set(newValue) {
             if let keyref = object.keyRef(for: field.rawValue) {
                 let existing = object[keyref] as! StringValue
-                existing.value = newValue
-                object[keyref] = existing
+                object[keyref] = existing.update(value: newValue)
             } else {
                 let keyref = KeyRef(value: field.rawValue, annotation: nil)
                 let stringValue = StringValue(value: newValue, annotation: nil)
@@ -209,8 +204,7 @@ extension FileReference {
             if let keyref = object.keyRef(for: field.rawValue) {
                 if let rawValue = newValue?.rawValue {
                     let existing = object[keyref] as! StringValue
-                    existing.value = rawValue
-                    object[keyref] = existing
+                    object[keyref] = existing.update(value: rawValue)
                 } else {
                     object[keyref] = nil
                 }
@@ -236,19 +230,17 @@ extension FileReference {
     }
 
 
-    subscript(field: RawRepresentableField) -> SourceTree {
+    subscript(field: StringValueField) -> SourceTree {
         set(newValue) {
             if let keyref = object.keyRef(for: field.rawValue) {
-                let existing = object[keyref] as! StringValue
-                existing.value = newValue.rawValue
-                object[keyref] = existing
+                object[keyref] = newValue.rawValue
             } else {
                 let keyref = KeyRef(value: field.rawValue, annotation: nil)
-                object[keyref] = StringValue(value: newValue.rawValue, annotation: nil)
+                object[keyref] = newValue.rawValue
             }
         }
         get {
-            let rawValue = object.string(for: field.rawValue)!
+            let rawValue = object.stringValue(for: field.rawValue)!
             return SourceTree(rawValue: rawValue)!
         }
     }
@@ -262,8 +254,7 @@ extension FileReference {
         set(newValue) {
             if let keyref = object.keyRef(for: field.rawValue) {
                 let existing = object[keyref] as! StringValue
-                existing.value = newValue
-                object[keyref] = existing
+                object[keyref] = existing.update(value: newValue)
             } else {
                 let keyref = KeyRef(value: field.rawValue, annotation: nil)
                 let stringValue = StringValue(value: newValue, annotation: nil)
@@ -285,8 +276,7 @@ extension FileReference {
             if let keyref = object.keyRef(for: field.rawValue) {
                 if let newValue = newValue {
                     let existing = object[keyref] as! StringValue
-                    existing.value = newValue
-                    object[keyref] = existing
+                    object[keyref] = existing.update(value: newValue)
                 } else {
                     object[keyref] = nil
                 }
@@ -337,19 +327,17 @@ extension Group {
         set(newValue) { self[.children] = newValue }
     }
 
-    subscript(field: RawRepresentableField) -> SourceTree {
+    subscript(field: StringValueField) -> SourceTree {
         set(newValue) {
             if let keyref = object.keyRef(for: field.rawValue) {
-                let existing = object[keyref] as! StringValue
-                existing.value = newValue.rawValue
-                object[keyref] = existing
+                object[keyref] = newValue.rawValue
             } else {
                 let keyref = KeyRef(value: field.rawValue, annotation: nil)
-                object[keyref] = StringValue(value: newValue.rawValue, annotation: nil)
+                object[keyref] = newValue.rawValue
             }
         }
         get {
-            let rawValue = object.string(for: field.rawValue)!
+            let rawValue = object.stringValue(for: field.rawValue)!
             return SourceTree(rawValue: rawValue)!
         }
     }
@@ -364,8 +352,7 @@ extension Group {
             if let keyref = object.keyRef(for: field.rawValue) {
                 if let newValue = newValue {
                     let existing = object[keyref] as! StringValue
-                    existing.value = newValue
-                    object[keyref] = existing
+                    object[keyref] = existing.update(value: newValue)
                 } else {
                     object[keyref] = nil
                 }
@@ -399,8 +386,7 @@ extension Pbxproj {
         set(newValue) {
             if let keyref = object.keyRef(for: field.rawValue) {
                 let existing = object[keyref] as! StringValue
-                existing.value = newValue
-                object[keyref] = existing
+                object[keyref] = existing.update(value: newValue)
             } else {
                 let keyref = KeyRef(value: field.rawValue, annotation: nil)
                 let stringValue = StringValue(value: newValue, annotation: nil)
@@ -458,8 +444,7 @@ extension Pbxproj {
             if let keyref = object.keyRef(for: field.rawValue) {
                 if let newValue = newValue {
                     let existing = object[keyref] as! StringValue
-                    existing.value = newValue
-                    object[keyref] = existing
+                    object[keyref] = existing.update(value: newValue)
                 } else {
                     object[keyref] = nil
                 }
@@ -535,8 +520,7 @@ extension RootObject {
         set(newValue) {
             if let keyref = object.keyRef(for: field.rawValue) {
                 let existing = object[keyref] as! StringValue
-                existing.value = newValue
-                object[keyref] = existing
+                object[keyref] = existing.update(value: newValue)
             } else {
                 let keyref = KeyRef(value: field.rawValue, annotation: nil)
                 let stringValue = StringValue(value: newValue, annotation: nil)
@@ -616,8 +600,7 @@ extension RootObject {
             if let keyref = object.keyRef(for: field.rawValue) {
                 if let newValue = newValue {
                     let existing = object[keyref] as! StringValue
-                    existing.value = newValue
-                    object[keyref] = existing
+                    object[keyref] = existing.update(value: newValue)
                 } else {
                     object[keyref] = nil
                 }
@@ -655,8 +638,7 @@ extension Target {
         set(newValue) {
             if let keyref = object.keyRef(for: field.rawValue) {
                 let existing = object[keyref] as! StringValue
-                existing.value = newValue
-                object[keyref] = existing
+                object[keyref] = existing.update(value: newValue)
             } else {
                 let keyref = KeyRef(value: field.rawValue, annotation: nil)
                 let stringValue = StringValue(value: newValue, annotation: nil)
@@ -685,8 +667,7 @@ extension Target {
         set(newValue) {
             if let keyref = object.keyRef(for: field.rawValue) {
                 let existing = object[keyref] as! StringValue
-                existing.value = newValue.rawValue
-                object[keyref] = existing
+                object[keyref] = existing.update(value: newValue.rawValue)
             } else {
                 let keyref = KeyRef(value: field.rawValue, annotation: nil)
                 object[keyref] = StringValue(value: newValue.rawValue, annotation: nil)

--- a/Sources/Pbxproj/FileReference.swift
+++ b/Sources/Pbxproj/FileReference.swift
@@ -46,7 +46,7 @@ public enum FileType: String {
     }
 }
 
-public enum SourceTree: String {
+public enum SourceTree: StringValue {
     case group = "\"<group>\""
     case builtProductsDir = "BUILT_PRODUCTS_DIR"
 }
@@ -56,7 +56,7 @@ final public class FileReference: IsaObject, ObjectsReferencing {
         case lastKnownFileType
         case explicitFileType
     }
-    enum RawRepresentableField: String {
+    enum StringValueField: String {
         case sourceTree
     }
     enum StringField: String {

--- a/Sources/Pbxproj/Group.swift
+++ b/Sources/Pbxproj/Group.swift
@@ -14,7 +14,7 @@ final public class Group: IsaObject, ObjectsReferencing {
     enum ArrayField: String {
         case children
     }
-    enum RawRepresentableField: String {
+    enum StringValueField: String {
         case sourceTree
     }
     enum OptionalStringField: String {

--- a/Tests/PbxprojTests/Helper.swift
+++ b/Tests/PbxprojTests/Helper.swift
@@ -11,13 +11,17 @@ func pathForFixture(fileName: String) -> String {
     #endif
 }
 
-func _pbxproj() -> Pbxproj {
+func _pbxprojPath() -> String {
     #if Xcode
         let path = pathForFixture(fileName: "test.pbxproj")
     #else
         let path = "Tests/PbxprojTests/test.pbxproj"
     #endif
-    return try! Pbxproj(path: path)
+    return path
+}
+
+func _pbxproj() -> Pbxproj {
+    return try! Pbxproj(path: _pbxprojPath())
 }
 
 func createPathAndFiles(path: String) {

--- a/Tests/PbxprojTests/PbxprojTests.swift
+++ b/Tests/PbxprojTests/PbxprojTests.swift
@@ -13,6 +13,8 @@ class PbxprojTests: XCTestCase {
         XCTAssertEqual(pbxproj.objectVersion, "46")
         let exObj: Object = [:]
         XCTAssertEqual(pbxproj.classes!, exObj)
+        let url = URL(fileURLWithPath: _pbxprojPath())
+        XCTAssertEqual(pbxproj.string(), String(data: try! Data(contentsOf: url), encoding: .utf8))
     }
     func testModification() {
         XCTAssertEqual(pbxproj.archiveVersion, "1")


### PR DESCRIPTION
Now it encapsulates (complicated) quoted String behavior.
Users don't have to strip double quoted String anymore.

Pbxproj trys to return stripped String via properties, and writes as is value.
In case you want to change from quoted String to unquoted String (vice-versa), you need to directly replace Object's value like this, instead of using `StringValue#update` API.

```swift
object[keyref] = StringValue.quoted(value: oldValue.value, annotation: oldValue.annotation)
```

SourceTree enum has quoted String rawValue `case group = "\"<group>\""`.
To handle this correctly, this PR introduced a new Sourcery handled field enum called `StringValueField`.
By declaring this enum, String enum with quoted rawValue will be read and written correctly.