### PR TITLE
Fix OptionalFileReferencingField to correctly handle baseConfigurationReference addition

### DIFF
--- a/Resources/SourceryTemplates/AutoPbxSubscript.stencil
+++ b/Resources/SourceryTemplates/AutoPbxSubscript.stencil
@@ -9,12 +9,20 @@ extension {{ type.name }} {
     {% if type.implements.ObjectsReferencing %}
     subscript(field: OptionalFileReferencingField) -> FileReference? {
         set(newValue) {
-            if let keyref = object.keyRef(for: field.rawValue) {
-                object[keyref] = newValue?.object
-            } else {
-                if let o = newValue?.object {
+            if let o = newValue?.object {
+                guard let id = objects.key(for: o) else {
+                    assertionFailure("id for fileref is not found in objects. Make sure you add fileref first using `addFiles` API.")
+                    return
+                }
+                if let keyref = object.keyRef(for: field.rawValue) {
+                    object[keyref] = keyref
+                } else {
                     let keyref = KeyRef(value: field.rawValue, annotation: nil)
-                    object[keyref] = objects.key(for: o)
+                    object[keyref] = id
+                }
+            } else {
+                if let keyref = object.keyRef(for: field.rawValue) {
+                    object[keyref] = nil
                 }
             }
         }

--- a/Sources/Pbxproj/AutoPbxSubscript.out.swift
+++ b/Sources/Pbxproj/AutoPbxSubscript.out.swift
@@ -32,12 +32,20 @@ extension BuildConfiguration {
 
     subscript(field: OptionalFileReferencingField) -> FileReference? {
         set(newValue) {
-            if let keyref = object.keyRef(for: field.rawValue) {
-                object[keyref] = newValue?.object
-            } else {
-                if let o = newValue?.object {
+            if let o = newValue?.object {
+                guard let id = objects.key(for: o) else {
+                    assertionFailure("id for fileref is not found in objects. Make sure you add fileref first using `addFiles` API.")
+                    return
+                }
+                if let keyref = object.keyRef(for: field.rawValue) {
+                    object[keyref] = keyref
+                } else {
                     let keyref = KeyRef(value: field.rawValue, annotation: nil)
-                    object[keyref] = objects.key(for: o)
+                    object[keyref] = id
+                }
+            } else {
+                if let keyref = object.keyRef(for: field.rawValue) {
+                    object[keyref] = nil
                 }
             }
         }

--- a/Sources/Pbxproj/BuildConfigurationList.swift
+++ b/Sources/Pbxproj/BuildConfigurationList.swift
@@ -42,5 +42,6 @@ public class BuildConfiguration: IsaObject, ObjectsReferencing {
     public init(object: Object, objects: Object) {
         self.object = object
         self.objects = objects
+        assert(isa == .XCBuildConfiguration)
     }
 }

--- a/Tests/PbxprojTests/BuildConfigurationTests.swift
+++ b/Tests/PbxprojTests/BuildConfigurationTests.swift
@@ -10,12 +10,19 @@ class BuildConfigurationTests: XCTestCase {
         self.pbxproj = _pbxproj()
     }
     func testMutateBaseConfigurationReference() {
+        // prepare files
         let c = pbxproj.rootObject.buildConfigurationList.buildConfigurations[0]
         cleanup(path: "foo")
         createPathAndFiles(path: "foo/Bar.xcconfig")
+        // test code
         try! pbxproj.rootObject.mainGroup.addFiles(paths: ["foo"])
         let fileref = pbxproj.fileReferences(named: "Bar.xcconfig")[0]
         c.baseConfigurationReference = fileref
         XCTAssertEqual(c.baseConfigurationReference?.fullPath, "foo/Bar.xcconfig")
+        guard let generatedId = pbxproj.objects.key(for: fileref.object) else {
+            XCTFail("generatedId iof fileref is not found in pbxproj.objects.")
+            return
+        }
+        XCTAssertEqual(generatedId, c.object.string(for: "baseConfigurationReference"))
     }
 }


### PR DESCRIPTION
Setter of ConfigurationList.baseConfigurationReference now correctly sets StringValue instead of FileReference Object.